### PR TITLE
PHOENIX-7488. Use central repo, not repository.apache.org

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -59,13 +59,6 @@
     <url>https://git-wip-us.apache.org/repos/asf?p=phoenix-thirdparty.git</url>
   </scm>
 
-  <repositories>
-    <repository>
-      <id>apache release</id>
-      <url>https://repository.apache.org/content/repositories/releases/</url>
-    </repository>
-  </repositories>
-
   <properties>
     <rename.offset>org.apache.phoenix.thirdparty</rename.offset>
     <guava.version>32.1.3-jre</guava.version>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Remove `repository.apache.org` definition, to let the build use `central` repo from super POM.

Please see last item about `repository.apache.org` at https://infra.apache.org/infra-ban.html.

https://issues.apache.org/jira/browse/PHOENIX-7488

## How was this patch tested?

Local build:

```
$ mvn -DskipTests clean package
...
[INFO] Reactor Summary for Apache Phoenix Third-Party Libs 2.1.1-SNAPSHOT:
[INFO] 
[INFO] Apache Phoenix Third-Party Libs .................... SUCCESS [  0.901 s]
[INFO] Apache Phoenix Relocated (Shaded) Guava ............ SUCCESS [  1.380 s]
[INFO] Apache Phoenix Patched and Relocated (Shaded) Commons-CLI SUCCESS [  0.392 s]
```